### PR TITLE
fix(convex-query-client): prevent crash when unsubscribing missing qu…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -259,8 +259,11 @@ export class ConvexQueryClient {
         // A query has been GC'd so no stale value will be available.
         // In Convex this means we should unsubscribe.
         case "removed": {
-          this.subscriptions[event.query.queryHash].unsubscribe();
-          delete this.subscriptions[event.query.queryHash];
+          const subscription = this.subscriptions[event.query.queryHash];
+          if (subscription) {
+            subscription.unsubscribe();
+            delete this.subscriptions[event.query.queryHash];
+          }
           break;
         }
         // A query has been requested for the first time.


### PR DESCRIPTION
fix(convex-query-client): prevent crash when unsubscribing missing query subscription

<!-- Describe your PR here. -->
This fixes a `TypeError: Cannot read property 'unsubscribe' of undefined` 
that occurred when a query was removed before its subscription was fully 
established. We now safely check for the subscription before calling 
`unsubscribe()`.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.