### PR TITLE
fix: bump convex-helpers dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/react-dom": "^18.0.0",
     "@vitejs/plugin-react": "^4.2.1",
     "convex": "workspace:*",
-    "convex-helpers": "^0.1.105",
+    "convex-helpers": "^0.1.114",
     "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.0.0",
     "npm-run-all2": "^8.0.0",


### PR DESCRIPTION
## Why
- `convex-helpers` is only used in the local `convex/schema.ts` example via `typedV`.
- The pinned dev dependency (`^0.1.105`) declares a `convex` peer of `^1.24.0`, which causes version mismatch warnings against this repo's newer Convex versioning.
- Bumping to `^0.1.114` aligns the helper package with current Convex releases (`convex` peer `^1.32.0`).

## What changed
- Updated `convex-helpers` in `package.json` from `^0.1.105` to `^0.1.114`.